### PR TITLE
Minor optimizations

### DIFF
--- a/QuartzWindowMgr.py
+++ b/QuartzWindowMgr.py
@@ -1,13 +1,32 @@
+import Quartz
 from Quartz import CGWindowListCopyWindowInfo, kCGWindowListExcludeDesktopElements, kCGWindowListOptionOnScreenOnly, kCGNullWindowID, CGWindowListCreateImage,  CGRectNull, kCGWindowListOptionIncludingWindow
+
+def getWindowInfo(win):
+    coordinates = win.valueForKey_('kCGWindowBounds')
+
+    return {
+        'ID': win.valueForKey_('kCGWindowNumber'),
+        'x':  coordinates.valueForKey_('X'),
+        'y':  coordinates.valueForKey_('Y'),
+        'w':  coordinates.valueForKey_('Width'),
+        'h':  coordinates.valueForKey_('Height'),
+    }
 
 class WindowMgr:
     """Encapsulates some calls to the quartz for window management"""
     def __init__ (self):
         pass
   
+    def getWindow(self, win_info):
+        try:
+            win = Quartz.CGWindowListCreateDescriptionFromArray([win_info['ID']])[0]
+            return getWindowInfo(win)
+        except:
+            return None
+
     def getWindows(self):
         '''
-        Return a list of tuples (windowID, window_title) for each real window.
+        Return a list of tuples (win_info, win_title) for each real window.
         '''
         window_list = CGWindowListCopyWindowInfo(kCGWindowListExcludeDesktopElements | kCGWindowListOptionOnScreenOnly, kCGNullWindowID)
 
@@ -18,17 +37,9 @@ class WindowMgr:
                 and win.valueForKey_('kCGWindowSharingState')
                 and win.valueForKey_('kCGWindowName')
             ):
-                coordinates = win.valueForKey_('kCGWindowBounds')
-
                 # weird format to match the win32 setup :/
                 filtered_list.append((
-                    {
-                        'ID': win.valueForKey_('kCGWindowNumber'),
-                        'x':  coordinates.valueForKey_('X'),
-                        'y':  coordinates.valueForKey_('Y'),
-                        'w':  coordinates.valueForKey_('Width'),
-                        'h':  coordinates.valueForKey_('Height'),
-                    },
+                    getWindowInfo(win),
                     win.valueForKey_('kCGWindowName')
                 ))
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can verify they are installed by running python from the command prompt and 
 
 `import win32ui`
 
-`import numpy
+`import numpy`
 
 
 You shouldnt get any errors. Then, exit python
@@ -45,17 +45,23 @@ OSX
 
 You need to have python3 and the pyobjc binding to access the Quartz APIs
 
-At the comment line, run:
+At the command line, run:
 
 `brew install python3 libtiff libjpeg webp little-cms2`
 
-`pip3 install -U pyobjc pillow`
+`pip3 install -U pyobjc pillow numpy`
 
 You can verify the installation is correct by checking this:
 
+`import PIL`
+
 `import Quartz`
 
-`import PIL`
+`import numpy`
+
+
+You shouldnt get any errors. Then, exit python
+`exit()`
 
 
 Running

--- a/Win32WindowMgr.py
+++ b/Win32WindowMgr.py
@@ -48,6 +48,9 @@ class WindowMgr:
                 return True
         return False
   
+    def getWindow(self, hwnd):
+        return hwnd if win32gui.IsWindow(hwnd) else None
+
     def getWindows(self):
         '''
         Return a list of tuples (handler, (width, height)) for each real window.

--- a/fastocr.py
+++ b/fastocr.py
@@ -19,6 +19,7 @@ IMAGE_SIZE = 7
 BLOCK_SIZE = IMAGE_SIZE+1
 IMAGE_MULT = 2
 GAP = (BLOCK_SIZE - IMAGE_SIZE) * IMAGE_MULT
+SCALED_IMAGE_SIZE = IMAGE_SIZE * IMAGE_MULT
 
 def setupColour(prefix, outputDict, digitList):
     #setup white digits
@@ -30,12 +31,12 @@ def setupColour(prefix, outputDict, digitList):
         
         img = img.convert('L')
         if IMAGE_MULT != 1:
-            img = img.resize((IMAGE_SIZE*IMAGE_MULT,
-                              IMAGE_SIZE*IMAGE_MULT),PIL.Image.ANTIALIAS)
+            img = img.resize((SCALED_IMAGE_SIZE,
+                              SCALED_IMAGE_SIZE),PIL.Image.ANTIALIAS)
         if NP_SUPPORTED:
             img = img.getdata()
             img = np.asarray(img)
-            img = np.reshape(img, (IMAGE_SIZE * IMAGE_MULT, IMAGE_SIZE*IMAGE_MULT))
+            img = np.reshape(img, (SCALED_IMAGE_SIZE, SCALED_IMAGE_SIZE))
         else:
             img = img.load()
 
@@ -53,7 +54,7 @@ def getDigit(img, pattern, startX, startY, red):
     if NP_SUPPORTED:
         scores = {}
         #img in y, x format
-        subImage = img[:,startX:startX + 14]
+        subImage = img[:,startX:startX + SCALED_IMAGE_SIZE]
 
         for digit in validDigits:
             diff = np.subtract(subImage, template[digit])
@@ -62,10 +63,9 @@ def getDigit(img, pattern, startX, startY, red):
 
     else:
         scores = {digit:0 for digit in validDigits}
-        MAX = IMAGE_SIZE * IMAGE_MULT
 
-        for y in range(MAX):
-            for x in range(MAX):
+        for y in range(SCALED_IMAGE_SIZE):
+            for x in range(SCALED_IMAGE_SIZE):
                 b = img[startX + x, startY + y]
 
                 for digit in digits:
@@ -97,7 +97,7 @@ def convertImg(img, count, show):
     t = time.time()
     img = contrastImg(img)        
     img = img.resize((((BLOCK_SIZE)*count-1)*IMAGE_MULT,
-                        IMAGE_SIZE*IMAGE_MULT),PIL.Image.ANTIALIAS)
+                        SCALED_IMAGE_SIZE),PIL.Image.ANTIALIAS)
     
     if show:
         img.show()
@@ -106,7 +106,7 @@ def convertImg(img, count, show):
         img = img.getdata()
         img = np.asarray(img)
         #img is in y,x format
-        img = np.reshape(img,(IMAGE_SIZE*IMAGE_MULT,-1))
+        img = np.reshape(img,(SCALED_IMAGE_SIZE,-1))
     else:
         img = img.load()
     

--- a/lib.py
+++ b/lib.py
@@ -12,8 +12,12 @@ else:
     from Win32WindowMgr import WindowMgr
     
 
-def getWindow():
+def getWindow(hwnd=None):
     wm = WindowMgr()
+
+    if hwnd:
+        return wm.getWindow(hwnd)
+
     windows = wm.getWindows()
     for window in windows:
         if window[1].startswith(WINDOW_NAME):


### PR DESCRIPTION
Hey there Alex,

I changed my mind on starting with big change in configs. Instead I thought I'd start by opening this  PR, for stuff I know for sure are optimizations (at least in OSX), and I'll work on introducing further optimisations, and refactoring the config system later.

So, 2 things in this PR, in 2 neatly independent commits:

commit 1: Remove the need to iterate over all windows when fetching the window info at each frame. There are now 2 nested loops: one to find the window, one to refresh its data. I haven't searched for the win API equivalent yet, so on windows, the behaviour is (should be!) unchanged. In OSX, the quartz API really are quite slow, and so commit 1 alone is enough to remove some `Warning, not scanning field fast enough` I could see.

commit 2: Introduce the non-numpy optimization I had made in my branch for `scoreDigit()` (renamed here `getDigit()`). The improved version is 2x as fast as the original (achieved by dropping repeat reads of the image pixels, and dropping sorting). Sadly, this is just for academic purpose you might say, because  the numpy version is still over 4x as fast as the improved version!! 😮. I don't expect anyone would not use the numpy version at this stage.

That said, assuming you do keep the `NP_SUPPORTED:False` code paths, the second commit also corrects an issue with the `img.getdata()` vs `img.load()`. `getdata()` was incorrectly applied for both paths, and that broke the tuple access into the image data.

This is tested (a bit) on OSX, no testing done in windows. That said, my wife just got herself a windows box, so I'll hopefully have a win environment to test my stuff in the future!

Looking forward to your comments and feedback! :)