### PR TITLE
Cleanup OSX classes to not use fake hwnd

### DIFF
--- a/QuartzCapture.py
+++ b/QuartzCapture.py
@@ -13,14 +13,17 @@ class QuartzCapture(object):
     def __init__(self):
         pass
     
-    def ImageCapture(self, rectangle, window):
+    def ImageCapture(self, rectangle, hwnd):
         x, y, w, h = rectangle
 
-        if w <= 0 or h <= 0 or not window or not window['ID']:
+        if w <= 0 or h <= 0 or not hwnd:
             return None
 
-        offsetX = window['x'] or 0
-        offsetY = window['y'] or 0
+        win = Quartz.CGWindowListCreateDescriptionFromArray([hwnd])[0]
+        coordinates = win.valueForKey_('kCGWindowBounds')
+
+        offsetX = coordinates.valueForKey_('X')
+        offsetY = coordinates.valueForKey_('Y')
 
         # can raise, correct later
         cgimg = Quartz.CGWindowListCreateImage(
@@ -29,8 +32,8 @@ class QuartzCapture(object):
                 Quartz.CGSize(w, h)
             ),
             Quartz.kCGWindowListOptionIncludingWindow | Quartz.kCGWindowListExcludeDesktopElements,
-            window['ID'],
-            0
+            hwnd,
+            Quartz.kCGWindowImageNominalResolution
         )
 
         width = Quartz.CGImageGetWidth(cgimg)

--- a/QuartzWindowMgr.py
+++ b/QuartzWindowMgr.py
@@ -1,49 +1,24 @@
-import Quartz
-from Quartz import CGWindowListCopyWindowInfo, kCGWindowListExcludeDesktopElements, kCGWindowListOptionOnScreenOnly, kCGNullWindowID, CGWindowListCreateImage,  CGRectNull, kCGWindowListOptionIncludingWindow
-
-def getWindowInfo(win):
-    coordinates = win.valueForKey_('kCGWindowBounds')
-
-    return {
-        'ID': win.valueForKey_('kCGWindowNumber'),
-        'x':  coordinates.valueForKey_('X'),
-        'y':  coordinates.valueForKey_('Y'),
-        'w':  coordinates.valueForKey_('Width'),
-        'h':  coordinates.valueForKey_('Height'),
-    }
+from Quartz import CGWindowListCreateDescriptionFromArray, CGWindowListCopyWindowInfo, kCGWindowListExcludeDesktopElements, kCGWindowListOptionOnScreenOnly, kCGNullWindowID
 
 class WindowMgr:
     """Encapsulates some calls to the quartz for window management"""
     def __init__ (self):
         pass
   
-    def checkWindow(self, win_info):
+    def checkWindow(self, hwnd):
         '''
         Checks if a window still exists
         '''
-        try:
-            win = Quartz.CGWindowListCreateDescriptionFromArray([win_info['ID']])[0]
-            return getWindowInfo(win)
-        except:
-            return None
+        return len(CGWindowListCreateDescriptionFromArray([hwnd])) == 1
 
     def getWindows(self):
         '''
-        Return a list of tuples (win_info, win_title) for each real window.
+        Return a list of tuples (win_id, win_title) for each real window.
         '''
         window_list = CGWindowListCopyWindowInfo(kCGWindowListExcludeDesktopElements | kCGWindowListOptionOnScreenOnly, kCGNullWindowID)
 
-        filtered_list = []
-
-        for win in window_list:
-            if (win.valueForKey_('kCGWindowIsOnscreen')
-                and win.valueForKey_('kCGWindowSharingState')
-                and win.valueForKey_('kCGWindowName')
-            ):
-                # weird format to match the win32 setup :/
-                filtered_list.append((
-                    getWindowInfo(win),
-                    win.valueForKey_('kCGWindowName')
-                ))
-
-        return filtered_list
+        return [
+            (win.valueForKey_('kCGWindowNumber'), win.valueForKey_('kCGWindowName'))
+            for win in window_list
+            if win.valueForKey_('kCGWindowSharingState') and win.valueForKey_('kCGWindowName')
+        ]


### PR DESCRIPTION
The osx Quartz classes were using a hackish data structure that was pretending to be "like" the  `hwnd` of win32. The data structure contained the window ID, position, and size of the desired window. 

This PR refactors both osx classes such that the window manager now only returns and cares about `hwnd` as window IDs, while the Capture class is the one that will fetch and use the position of the window.

The resulting code for osx is now much more like its win32 counterpart. 

The PR also fixes OSX for cases where the window moves. Since `hwnd` was containing the window position, the change from `getWindow()` to `checkWindow()`, which was no longer updating `hwnd`, caused capture areas to have incorrect offsets when the window moved.



