### PR TITLE
Set requirements for osx

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ You need to have python3 and the pyobjc binding to access the Quartz APIs
 
 At the command line, run:
 
-`brew install python3 libtiff libjpeg webp little-cms2`
+`brew install python3 libtiff libjpeg webp little-cms2 opencv@2`
 
-`pip3 install -U pyobjc pillow numba numpy ConfigUpdater cv2`
+`pip3 install -r requirements-osx.txt`
 
 You can verify the installation is correct by checking this:
 

--- a/requirements-osx.txt
+++ b/requirements-osx.txt
@@ -1,0 +1,7 @@
+autobahn[twisted]
+ConfigUpdater
+numba
+numpy
+opencv-python
+pillow
+pyobjc


### PR DESCRIPTION
Small update for the OSX requirements.

The calibrator app does not render well on OSX yet. I'll see if I can spend some time to look into it, but no promises 😰😅.

![image](https://user-images.githubusercontent.com/935223/66055903-e140f180-e568-11e9-94b8-11e810718770.png)


