### PR TITLE
OSX: Convert window capture to RGB at source

### DIFF
--- a/WinCap/QuartzCapture.py
+++ b/WinCap/QuartzCapture.py
@@ -42,7 +42,7 @@ class QuartzCapture(object):
         bpr = Quartz.CGImageGetBytesPerRow(cgimg)
 
         # Convert to PIL Image.  Note: CGImage's pixeldata is BGRA
-        return Image.frombuffer("RGBA", (width, height), pixeldata, "raw", "BGRA", bpr, 1)
+        return Image.frombuffer("RGBA", (width, height), pixeldata, "raw", "BGRA", bpr, 1).convert('RGB')
 
 
 imgCap = QuartzCapture()

--- a/calibration/ImageCanvas.py
+++ b/calibration/ImageCanvas.py
@@ -13,7 +13,7 @@ class ImageCanvas(tk.Canvas):
         
     def updateImage(self, image):        
         if image is not None:            
-            self.ph = ImageTk.PhotoImage(image.convert('RGB'))
+            self.ph = ImageTk.PhotoImage(image)
             
             # create image if not existing...
             if self._img is None:


### PR DESCRIPTION
The `RGBA` window capture in OSX is confusing `njit` (RGBA pixels tuples have 4 entries, while RGB tuples only 3)

I had initially added the `convert('RGB')` into `ImageCanvas`, but best to do it at the source at capture time in OSX for compatibility with everything else thereafter.

The Calibrator app still works, and njit gives the same performance boost in OSX as it does in windows 👍 

In case you wonder, I did try to set the raw format supplied to `Image.frombuffer()` to `RGB` but that doesn't work. Conversion must be done after capture :/
