### PR TITLE
Capture once then extract areas with PIL

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -9,6 +9,8 @@ multi_thread = 2
 # Supports scores past 999999 via A00000 to F99999
 support_hex_score = True
 scan_rate = 30
+# WINDOW_N_SLICE or DIRECT_CAPTURE
+tasks_capture_method = DIRECT_CAPTURE
 
 [stats]
 read_stats = False

--- a/config.py
+++ b/config.py
@@ -17,6 +17,7 @@ class Configuration:
         self.threads = literal_eval(parser['performance']['multi_thread'])
         self.hexSupport = parser['performance'].getboolean('support_hex_score') 
         self.scanRate = literal_eval(parser['performance']['scan_rate'])
+        self.tasksCaptureMethod = parser['performance']['tasks_capture_method']
         
         #stats
         self.capture_stats = parser['stats'].getboolean('read_stats')

--- a/main.py
+++ b/main.py
@@ -252,8 +252,9 @@ def main(onCap, checkNetworkClose):
             # run all tasks (in separate threads if MULTI_THREAD is enabled)
             result = runTasks(p, rawTasks)
 
-            #fix score's first digit. 8 to B and B to 8 depending on last state.
-            result['score'] = scoreFixer.fix(result['score'])
+            if config.hexSupport:
+                #fix score's first digit. 8 to B and B to 8 depending on last state.
+                result['score'] = scoreFixer.fix(result['score'])
 
             # update our accumulator
             if USE_STATS_FIELD:


### PR DESCRIPTION
Possible implementation of the "Capture Once Then Slice with PIL" approach.

Advantage of single capture is to not have race condition inconsistencies with multiple concurrent captures. The slicing and OCR can still be done in threads (although I haven't tested that on OSX)


Some notes:
* Using partials to capture the tasks call args, only the captured image itself needs to be additionally supplied in the run loop into each task
* The run loop is changed to not have to make any conditional decisions on what to run, all the tasks are computed as soon as the window is found
* I have not yet changed `captureAndOCRBoardPiece` which is used is the `statsFieldMulti` thread. I haven't really thought about it yet, but wanted your opinion on the rest of the approach before doing further work.

Things seem to run at acceptable speed on OSX, but because multi-threading isn't working, I can't test that. The code should be ready for it though. Pls try it out in windows and let me know. 

Any feedback welcome :)

Bonus: Only run scoreFixer when hex support is on (in separate commit)