### PR TITLE
Add OpenCV capturing support

### DIFF
--- a/WinCap/OpenCVCapture.py
+++ b/WinCap/OpenCVCapture.py
@@ -1,0 +1,66 @@
+import cv2
+import os
+from PIL import Image
+import time
+
+from config import config
+
+
+class WindowMgr():
+    def checkWindow(self, ocv2_device_id):
+        return True
+
+    def getWindows(self):
+        ocv2_device_id = int(config.WINDOW_NAME)
+
+        return [[ocv2_device_id, config.WINDOW_NAME]]
+
+
+class OpenCVMgr():
+    def __init__(self):
+        self.inputDevice = None
+        self.imgBuf = None
+        self.frameCount = 0
+
+    def videoCheck(self, ocv2_device_id):
+        if self.inputDevice is None:
+            self.inputDevice = cv2.VideoCapture(ocv2_device_id)
+            time.sleep(1)  # needed for Catalina, otherwise NextFrame would be black
+            self.NextFrame()
+
+    def ImageCapture(self, rectangle, ocv2_device_id):
+        self.videoCheck(ocv2_device_id)
+
+        return self.imgBuf.crop([
+            rectangle[0],
+            rectangle[1],
+            rectangle[0] + rectangle[2],
+            rectangle[1] + rectangle[3],
+        ])
+
+    def NextFrame(self):
+        if self.inputDevice.isOpened():
+            ret, cv2_im = self.inputDevice.read()
+            if ret:
+                cv2_im = cv2.cvtColor(cv2_im, cv2.COLOR_BGR2RGB)
+                self.imgBuf = Image.fromarray(cv2_im)
+                self.frameCount += 1
+                if self.frameCount % 1000 == 0:
+                    print ('frames', self.frameCount)
+                return True
+
+        return False
+
+
+imgCap = OpenCVMgr()
+
+
+def ImageCapture(rectangle, hwndTarget):
+    global imgCap
+    return imgCap.ImageCapture(rectangle, hwndTarget)
+
+
+def NextFrame():
+    # returns false if we want to exit the program
+    global imgCap
+    return imgCap.NextFrame()

--- a/lib.py
+++ b/lib.py
@@ -4,7 +4,10 @@ from config import config
 import platform
 
 #decide which file capture method we are using.
-if config.captureMethod == 'FILE':
+if config.captureMethod == 'OPENCV':
+    import WinCap.OpenCVCapture as WindowCapture
+    from WinCap.OpenCVCapture import WindowMgr
+elif config.captureMethod == 'FILE':
     import WinCap.FileCapture as WindowCapture
     from WinCap.FileCapture import WindowMgr
 elif platform.system() == 'Darwin':


### PR DESCRIPTION
### Context

The code was 99% done by @timotheeg and from https://github.com/timotheeg/NESTrisOCR/tree/das_trainer_w_field_color_interpolation.

It has been tested to work on Mac OS X 10.14 Mojave & 10.15 Catalina.

Windows is untested though.

### Usage
- Set `calibration.window_name` to the OpenCV device ID of the capturing device (try 0, 1, 2, 3...)
- Set `calibration.capture_method` to `OPENCV`.