### PR TITLE
Add more digit patterns

### DIFF
--- a/OCRAlgo/DigitOCR.py
+++ b/OCRAlgo/DigitOCR.py
@@ -9,7 +9,13 @@ import sys
 data = {}
 redData = {}
 digits = ['0','1','2','3','4','5','6','7','8','9','null']
-digitsLetters = digits + ['A','B','C','D','E','F']
+
+digitsMap = {
+    'D': digits,
+    'A': digits + ['A','B','C','D','E','F'],
+    'B': ['0', '1', 'null'],
+    'T': ['0', '1', '2', 'null'],
+}
 
 MONO = True
 IMAGE_SIZE = 7
@@ -42,14 +48,14 @@ def setupColour(prefix, outputDict, digitList):
         outputDict[digit] = img
         
 def setupData():
-    setupColour('sprite_templates/', data, digitsLetters) #setup white
-    setupColour('sprite_templates/red', redData, digits) #setup red
+    setupColour('sprite_templates/', data, digitsMap['A']) #setup white
+    setupColour('sprite_templates/red', redData, digitsMap['D']) #setup red
 
 
 def getDigit(img, pattern, startX, startY, red):
     template = redData if red else data
-    validDigits = digitsLetters if pattern == 'A' else digits
-    
+    validDigits = digitsMap[pattern]
+
     scores = {}
     #img in y, x format
     subImage = img[:,startX:startX + SCALED_IMAGE_SIZE]

--- a/README.md
+++ b/README.md
@@ -111,3 +111,21 @@ If you are in a menu, it will more likely output
 `{'lines': None, 'score', None, 'level', None}`
 
 It will output via TCP to port 3338 by default. This is to connect to other applications that actually use the data.
+
+
+OCR Algorythm
+===
+
+The OCR algoryhm is straight forward. A pixel perfect copy of the digits `0123456789`, and hex letters `ABCDEF`, is kept and 2x scaled up (i.e. 14 pixels x 14 pixels) with aliasing.
+
+Digits in input frame are extracted and similarly scaled to 14x14, and then individually compared against all the templates. The closest match (least distance) is considered to be the actual digit.
+
+The computation is very fast thanks to using numpy. Yet one obvious speed optimization is, with knowledge of the input, to reduce the templates to compare to.
+
+For example:
+* The lines counter will never have hex letters, so we do not need to compare against them
+* The score will only be digits **except** for the first character which could include hex letters (if a Game Genie code is used)
+* While some players are now playing beyond level 29, it is still the kill screen for most players, and so counting to 29 is sufficient for most (first character can only be `012`)
+
+Based on your skill level, and the game genie code you are using, you may edit the OCR patterns in the file [main.py](main.py). In there, look up the dictionnary `PATTERNS`, and edit it as desired.
+

--- a/config.ini
+++ b/config.ini
@@ -8,6 +8,7 @@ twitch=twitch.tv/urlhere
 multi_thread = 2
 # Supports scores past 999999 via A00000 to F99999
 support_hex_score = True
+support_beyond_level_29 = False
 scan_rate = 30
 # WINDOW_N_SLICE or DIRECT_CAPTURE
 tasks_capture_method = DIRECT_CAPTURE

--- a/config.py
+++ b/config.py
@@ -16,6 +16,7 @@ class Configuration:
         #performance
         self.threads = literal_eval(parser['performance']['multi_thread'])
         self.hexSupport = parser['performance'].getboolean('support_hex_score') 
+        self.beyondLevel29Support = parser['performance'].getboolean('support_beyond_level_29')
         self.scanRate = literal_eval(parser['performance']['scan_rate'])
         self.tasksCaptureMethod = parser['performance']['tasks_capture_method']
         
@@ -81,8 +82,11 @@ class Configuration:
         self.setItem('performance','multi_thread', threads)    
     
     def setHexSupport(self, support):
-        self.setItem('performance','support_hex_score', support)    
-    
+        self.setItem('performance','support_hex_score', support)
+
+    def setBeyondLevel29Support(self, support):
+        self.setItem('performance','support_beyond_level_29', support)
+
     def setCaptureStats(self, toCapture):
         self.setItem('stats','read_stats', toCapture)    
     

--- a/main.py
+++ b/main.py
@@ -19,14 +19,17 @@ from tkinter import messagebox, Tk
 import time
 import sys
 
-#patterns for digits. 
-#A = 0->9 + A->F, 
+#patterns for digits.
+#A = 0->9 + A->F,
 #D = 0->9
+#B = 0->1 (das value only 00 to 16, so first digit can check 0 or 1 only) (B for Binary)
+#T = 0->2 (majority of humans play up to 30, so first digit of level could be 0-2 only) (T for Triplet)
 PATTERNS = {
     'score': 'ADDDDD' if config.hexSupport else 'DDDDDD',
     'lines': 'DDD',
     'level': 'AA',
-    'stats': 'DDD'
+    'stats': 'DDD',
+    'das':   'BD'
 }
 
 STATS_METHOD  = config.stats_method #can be TEXT or FIELD.

--- a/main.py
+++ b/main.py
@@ -23,11 +23,11 @@ import sys
 #A = 0->9 + A->F,
 #D = 0->9
 #B = 0->1 (das value only 00 to 16, so first digit can check 0 or 1 only) (B for Binary)
-#T = 0->2 (majority of humans play up to 30, so first digit of level could be 0-2 only) (T for Triplet)
+#T = 0->2 (majority of humans play up to level 29, so first digit of level could be 0-2 only) (T for Triplet)
 PATTERNS = {
     'score': 'ADDDDD' if config.hexSupport else 'DDDDDD',
     'lines': 'DDD',
-    'level': 'TD',
+    'level': 'AA' if config.beyondLevel29Support else 'TD',
     'stats': 'DDD',
     'das':   'BD'
 }

--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ import sys
 PATTERNS = {
     'score': 'ADDDDD' if config.hexSupport else 'DDDDDD',
     'lines': 'DDD',
-    'level': 'AA',
+    'level': 'TD',
     'stats': 'DDD',
     'das':   'BD'
 }


### PR DESCRIPTION
I'm going to try to submit a few PRs for some of the stuff I've had dormant for a while. It's quite hard to extract changesets that are nicely self contained (and will reduce my pain in resolving code conflicts later 😅) 

So, starting with a simple one here, hopefully straight forward.

There are are some minor optimizations that can be done in OCR. If you OCR `das` with Das Trainer, values are from `00` to `16`, so we can introduce a digit pattern of `B` to denote `[0, 1]`. Pattern `B` is not yet used in the code, but added anyway :)

Similarly, for the vast majority of human players, `level` will not reach beyond 29. Tetris renders level >= 30 with hex characters, so to cover everything, the pattern needs to be `AA`, but for most players for whom level 29 is kill screen, that's overkill to compare against. So I introduce another set `T` (for triplet) for `[0, 1, 2]`, such that players can use the pattern `TD` for `level`.

I didn't know if you'd want to keep `AA` for level as default or use `TD` as default, so I made that one change in a single commit that can easily be removed if needed :)

Cheers!