### PR TITLE
OpenCV: support video streams

### DIFF
--- a/WinCap/OpenCVCapture.py
+++ b/WinCap/OpenCVCapture.py
@@ -11,7 +11,9 @@ class WindowMgr():
         return True
 
     def getWindows(self):
-        ocv2_device_id = int(config.WINDOW_NAME)
+        # we keep cv2_device_id as string for now, so it is always truthy
+        # If we cast to int now, device id 0 will not be truthy and can't be used
+        ocv2_device_id = config.WINDOW_NAME
 
         return [[ocv2_device_id, config.WINDOW_NAME]]
 
@@ -24,6 +26,15 @@ class OpenCVMgr():
 
     def videoCheck(self, ocv2_device_id):
         if self.inputDevice is None:
+            try:
+                # OpenCV support local device IDs AND stream URLs
+                # Let's do a blind cast attempt to int
+                #  - if it can cast, we get a local device ID
+                #  - if it cannot cast, we assume we have a stream URL and use it as is
+                ocv2_device_id = int(ocv2_device_id)
+            except:
+                pass
+
             self.inputDevice = cv2.VideoCapture(ocv2_device_id)
             time.sleep(1)  # needed for Catalina, otherwise NextFrame would be black
             self.NextFrame()


### PR DESCRIPTION
The current OpenCV capture class has 2 minor issues
1. it casts the device id to `int` immediately, which is then tested for truthiness in `main.py` (because for window capture, it represents the window ID), but openCV device ID can be `0`, which is falsy
2. Casting to int implies the user only uses openCV for local device capture. However OpenCV supports many string-based identifier, like stream URLs.

This PR:
1.  delays the casting to `int`: the opencv id is kept as string initially, so it is truthy even if it's `'0'`
2.  handles casting failure and passes the opencv ID as-is.

2) above means that a casting failure is treated as the user passing a stream on purpose rather than being a mistake.

On real mistakes, openCV itself will complain.

