### PR TITLE
Allow CLI arg to specify config file

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,3 +1,5 @@
+import argparse
+
 import configparser
 from configupdater import ConfigUpdater
 from ast import literal_eval #safe version of eval
@@ -146,9 +148,16 @@ class Configuration:
     def setNetProtocol(self, val):
         self.setItem('network','protocol', val)
     
-updater = ConfigUpdater()        
-updater.read('config.ini')
 
-config = Configuration('config.ini', updater)
+# Should probably be in main.py and calibrate.py
+# But works fine here to extract just one arg
+parser = argparse.ArgumentParser()
+parser.add_argument('--config', default='config.ini')
+args = parser.parse_args()
+config_filename = args.config
 
 
+updater = ConfigUpdater()
+updater.read(config_filename)
+
+config = Configuration(config_filename, updater)


### PR DESCRIPTION
When one has multiple input system (capture device, emulator, etc.), it might be useful to store multiple local config file and to pass the desired one to NEStrisOCR. 

`argparse` is normally not used in module files (typically used in main instead in some sort of bootstrapping sequence), but I put in `config.py`anyway because:
* config.py is already is used as "initialized on import" by both `main.py` and `calibrate.py`
* NESTrisOCR doesn't use CLI args, so it's not conflicting with other stuff
* this is a tiny changeset to get the job done

Cheers!