### PR TITLE
Add GitHub actions for formatting and linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade pre-commit
+      - name: Lint
+        run: pre-commit run --all-files

--- a/ocr_state/field_state.py
+++ b/ocr_state/field_state.py
@@ -1,7 +1,7 @@
 ﻿# Todo: numba optimize for numTiles
 # Make sure we account for rotating piece above field, as this reduces
 # Blockcount by 2
-class FieldState(object):
+class FieldState(object):  # noqa: E302
     def __init__(self, data):
         self.data = data
 


### PR DESCRIPTION
Looks at the 2 commits 😍 No one will be able to merge "illegal" code with the guardian of those automatic checks in the future.

All the black formatting and flake8 linting have to pass, before a green tick is given. Enterprise grade 💪 