### PR TITLE
Add ability to specify config file

### DIFF
--- a/nestris_ocr/config.py
+++ b/nestris_ocr/config.py
@@ -1,3 +1,4 @@
+import argparse
 from cached_property import threaded_cached_property
 from collections import OrderedDict
 import json
@@ -136,4 +137,11 @@ class Config:
         return spawn_subimage(self["calibration.pct.field"])
 
 
-config = Config("config.json")
+# Should probably be in main.py and calibrate.py
+# But works fine here to extract just one arg
+parser = argparse.ArgumentParser()
+parser.add_argument("--config", default="config.json")
+args = parser.parse_args()
+config_filename = args.config
+
+config = Config(config_filename)


### PR DESCRIPTION
Port PR #22 to latest master, because the feature was accidentally removed in PR #27

Now allows to start with (for example)
```
python3 main.py --config=config.p1.json
python3 main.py --config=config.p2.json
```

@blakegong @alex-ong 