### PR TITLE
Restreamer Script: Allow running without a local VLC server

### DIFF
--- a/scripts/readme.md
+++ b/scripts/readme.md
@@ -4,17 +4,24 @@ Tetris and OCR related scripts will be found in this folder and documented in th
 
 `scripts/restream.py` is a script to allow a restreamer to quickly get started to OCR from a CTM Stencil-ready twitch stream.
 
-This can alow a restreamer to compute stats and redraw a stream, or even render a 1v1 competition while computing score differentials against players.
+This can allow a restreamer to compute stats and redraw a stream, or even render a 1v1 competition while computing score differential between players.
+
+To run this script, you are expected to have downloaded and installed the following CLI tools:
+* [streamlink](https://streamlink.github.io/install.html)
+* [vlc](https://www.videolan.org/index.html)
+* [ffmpeg](https://ffmpeg.org/download.html)
+
 
 The script can be invoked from NESTrisOCR's root folder as:
-```
+```bash
 python -m scripts.restream PLAYER_1_TWITCH_USER_NAME 1
 
 # and for player 2
 python -m scripts.restream PLAYER_1_TWITCH_USER_NAME 2
 ```
 
-To test this, visit https://www.twitch.tv/directory/game/Tetris to see who is streaming with Stencil.
+To test this, visit https://www.twitch.tv/directory/game/Tetris to see who is streaming with CTM Stencil. Select the twitch user name of a player and use it in the command for player 1 above.
+
 
 The script does the following:
 
@@ -26,12 +33,20 @@ The script does the following:
 * Starts NESTrisOCR with that config
 
 
-The VLC servers will be accessible from the following 2 URLs (for player 1 and 2 respectively)
+The VLC servers will be accessible locally from the following 2 URLs (for player 1 and 2 respectively):
 
 * http://localhost:8081 for player 1
 * http://localhost:8082 for player 2
 
-NESTrisOCR will push the game data to ports 4001 and 4002 for player 1 and player 2 respectively, where a suitable renderer may be listening (like [NESTrisStatsUI](https://github.com/timotheeg/NESTrisStatsUI)) .
+
+NESTrisOCR will push the game data to ports 4001 and 4002 for player 1 and player 2 respectively, where a suitable renderer may be listening (like [NESTrisStatsUI](https://github.com/timotheeg/NESTrisStatsUI)).
+
+
+Note: running the local VLC server on windows doesn't seem to work very well (for some reason???). You can forgo VLC and have NESTrisOCR read straight from the twitch stream. This can be done by adding the CLI arg `--novlc` like this:
+
+```bash
+python -m scripts.restream --novlc PLAYER_1_TWITCH_USER_NAME 1
+```
 
 
 


### PR DESCRIPTION
@blakegong  tried the restreamer script on windows but VLC is not liking being told to set up a local server for some reason 😑😢

The reason we have a local VLC server in the first place is so that NEStrisOCR and OBS could both read from the local server, rather than both reading from the twitch servers.

Maybe showing the player is not important, and only OCR really is. Or perhaps loading the twitch stream twice is fine anyway.

I should eventually figure out how to to run VLC in local server mode in windows, but I do not have a windows box 😑 . So in this PR I'm for now adding an option `--novlc` to the script, to have NEStrisOCR read straight from the twitch URL (which we can just do because openCV rocks 💪)

