### PR TITLE
Restore text stats

### DIFF
--- a/nestris_ocr/ocr_state/piece_stats.py
+++ b/nestris_ocr/ocr_state/piece_stats.py
@@ -61,7 +61,19 @@ class PieceStatAccumulator(object):
     # used for naive implementation
     def rewrite(self, pieces):
         self.lock.acquire()
-        self.T, self.J, self.Z, self.O, self.S, self.L, self.I = pieces  # noqa: E741
+        if isinstance(pieces, dict):
+            for [piece, value] in pieces.items():
+                setattr(self, piece, value)
+        else:
+            (
+                self.T,
+                self.J,
+                self.Z,
+                self.O,
+                self.S,
+                self.L,
+                self.I,
+            ) = pieces  # noqa: E741
         self.lock.release()
 
     # returns if a new piece spawned

--- a/nestris_ocr/scan_strat/naive_strategy.py
+++ b/nestris_ocr/scan_strat/naive_strategy.py
@@ -14,6 +14,7 @@ from nestris_ocr.scan_strat.scan_helpers import (
     scan_das_current_piece,
     scan_das_current_piece_das,
     scan_das_instant_das,
+    scan_stats_text,
 )
 
 # from FullStateOptimizer.Transition import TRANSITION
@@ -142,6 +143,5 @@ class NaiveStrategy(BaseStrategy):
         self.instant_das = scan_das_instant_das(img, "OO")
 
     def scan_stats_text(self, img):
-        pass
-        # pieces = scan_stats_text(img)
-        # self.piece_stats.rewrite(pieces)
+        pieces = scan_stats_text(img)
+        self.piece_stats.rewrite(pieces)

--- a/nestris_ocr/scan_strat/scan_helpers.py
+++ b/nestris_ocr/scan_strat/scan_helpers.py
@@ -11,13 +11,18 @@ from nestris_ocr.utils.lib import mult_rect
 
 
 PATTERNS = {
-    "score": "ADDDDD",
+    "score": "DDDDDD",
     "lines": "DDD",
-    "level": "AA",
+    "level": "TD",
     "stats": "DDD",
     "das": "BD",
 }
 
+if config["performance.support_hex_score"]:
+    PATTERNS["score"] = "ADDDDD"
+
+if config["performance.support_hex_level"]:
+    PATTERNS["level"] = "AA"
 
 # A few notes
 # We always support scores past maxout

--- a/nestris_ocr/scan_strat/scan_helpers.py
+++ b/nestris_ocr/scan_strat/scan_helpers.py
@@ -14,7 +14,7 @@ PATTERNS = {
     "score": "DDDDDD",
     "lines": "DDD",
     "level": "TD",
-    "stats": "DDD",
+    "stats": "TDD",
     "das": "BD",
 }
 

--- a/nestris_ocr/scan_strat/scan_helpers.py
+++ b/nestris_ocr/scan_strat/scan_helpers.py
@@ -6,9 +6,9 @@ from nestris_ocr.ocr_algo.board import parseImage as processBoard
 from nestris_ocr.ocr_algo.preview2 import parseImage as processPreview
 from nestris_ocr.ocr_algo.dasTrainerCurPiece import parseImage as processCurrentPiece
 from nestris_ocr.ocr_algo.piece_stats_spawn import parseImage as processSpawn
+from nestris_ocr.ocr_algo.piece_stats_text import generate_stats
 from nestris_ocr.utils import xywh_to_ltrb
 from nestris_ocr.utils.lib import mult_rect
-
 
 PATTERNS = {
     "score": "DDDDDD",
@@ -37,7 +37,6 @@ def get_window_areas():
         "field": config["calibration.pct.field"],
         "black_n_white": config["calibration.pct.black_n_white"],
         "stats2": config.stats2_percentages,
-        "stats": config["calibration.pct.stats"],
         "preview": config["calibration.pct.preview"],
         "flash": config["calibration.pct.flash"],
         # das trainer
@@ -49,6 +48,16 @@ def get_window_areas():
     base_map = {
         key: xywh_to_ltrb(mult_rect(config["calibration.game_coords"], value))
         for key, value in mapping.items()
+    }
+
+    # stats are handled in a special manner
+    base_map["stats"] = {
+        piece: xywh_to_ltrb(coords)
+        for (piece, coords) in generate_stats(
+            config["calibration.game_coords"],
+            config["calibration.pct.stats"],
+            config["calibration.pct.score"][3],
+        ).items()
     }
 
     # calibration of the color blocks include the edges (black),
@@ -167,8 +176,15 @@ def scan_spawn(full_image, colors):
     return processSpawn(sub_image, colors)
 
 
-def scan_stats_text(full_image):
-    raise NotImplementedError
+def scan_stats_text(full_image, digit_mask="OOO"):
+    pattern = mask_pattern(PATTERNS["stats"], digit_mask)
+    res = {}
+
+    for [piece, area] in WINDOW_AREAS["stats"].items():
+        sub_image = get_sub_image(full_image, area)
+        res[piece] = processDigits(sub_image, pattern, red=True)
+
+    return res
 
 
 def scan_preview(full_image, colors):


### PR DESCRIPTION
⚠️ Merge #57 before checking this PR!

Restore naive piece stats OCR.

Other methods, relying on field inspection don't work well on twitch streams with varying quality, and frame drops. Piece stats are more "stable" for such cases.

Tested on OSX from a twitch stream.

@alex-ong @blakegong 