### PR TITLE
Scripts: restream: Save fine tuning config files by restreamer

### DIFF
--- a/nestris_ocr/config_class.py
+++ b/nestris_ocr/config_class.py
@@ -13,7 +13,7 @@ CONFIG_DEFAULTS = {
 
     "performance.support_hex_score": True,
     "performance.support_hex_level": True,
-    "performance.scan_rate": 30,
+    "performance.scan_rate": 30.0,
 
     "stats.enabled": False,
     "stats.capture_method": "FIELD",
@@ -126,7 +126,7 @@ class Config:
         default = CONFIG_DEFAULTS[key]
         if (
             isinstance(default, int) and not isinstance(value, int)
-            or isinstance(default, float) and not isinstance(value, float)
+            or isinstance(default, float) and (not isinstance(value, float) and not isinstance(value, int))
             or isinstance(default, str) and not isinstance(value, str)
             or isinstance(default, list) and not (isinstance(value, list) or isinstance(value, tuple))
         ):

--- a/scripts/restream.py
+++ b/scripts/restream.py
@@ -7,7 +7,7 @@ import re
 from nestris_ocr.config_class import Config
 
 
-TEMPLATE_FILE = "scripts/config.stream.template.json"
+TEMPLATE_FILE = "scripts/restream_configs/_template.json"
 
 CAP_RATIOS = [1233 / 1920, 1]  # based on the stencil dimensions for 1080p
 
@@ -106,11 +106,13 @@ def setup_player(twitch_name, player_num, local_vlc=True):
     # ==================================
     # 3. write player config file from template
 
-    player_config_file = "config.competition.p{}.json".format(player_num)
+    player_config_file = "scripts/restream_configs/{}.json".format(twitch_name)
 
-    os.remove(player_config_file)
+    template = (
+        player_config_file if os.path.isfile(player_config_file) else TEMPLATE_FILE
+    )
 
-    config = Config(player_config_file, auto_save=False, default_config=TEMPLATE_FILE)
+    config = Config(player_config_file, auto_save=False, default_config=template)
 
     config["player.name"] = twitch_name
     config["player.twitch_url"] = twitch_url

--- a/scripts/restream_configs/_template.json
+++ b/scripts/restream_configs/_template.json
@@ -5,8 +5,8 @@
   "performance.support_hex_score": false,
   "performance.support_hex_level": false,
   "performance.scan_rate": 30,
-  "stats.enabled": false,
-  "stats.capture_method": "FIELD",
+  "stats.enabled": true,
+  "stats.capture_method": "TEXT",
   "capture.method": "STREAM",
   "capture.source_id": "STREAM_URL",
   "capture.source_extra_data": "",
@@ -108,6 +108,6 @@
   "network.host": "127.0.0.1",
   "network.port": 4444,
   "network.protocol": "LEGACY",
-  "debug.print_packet": false,
+  "debug.print_packet": true,
   "debug.print_benchmark": false
 }

--- a/scripts/restream_configs/readme.md
+++ b/scripts/restream_configs/readme.md
@@ -1,0 +1,1 @@
+Player template files go here to save fine tuning (and your time!)


### PR DESCRIPTION
Script was only storing config file by player 1 / player 2 from the raw template, which mean any fine tuning calibration being done for a particular user was lost at each game, which was super annoying.

This PR updates the restream script to store template files by twitch usernames. Restreaming the same user multiple times should be much faster now ✌️ 

Bonus:
* The config type check for float is a little too strict, now accepts floats and ints (needed for stream fps)
* Default template should read the line stats (field is not reliable considering random frame drops)
