### PR TITLE
Update state without checking values

### DIFF
--- a/nestris_ocr/scan_strat/base_strategy.py
+++ b/nestris_ocr/scan_strat/base_strategy.py
@@ -30,7 +30,7 @@ class BaseStrategy(object):
         self.start_level = None
         self.field = None
         self.preview = None
-        self.gameid = 0
+        self.gameid = 1
         self.piece_stats = PieceStatAccumulator()
         self.gamestate = GameState.MENU
         self.cur_piece = None

--- a/nestris_ocr/scan_strat/naive_strategy.py
+++ b/nestris_ocr/scan_strat/naive_strategy.py
@@ -25,6 +25,7 @@ from nestris_ocr.scan_strat.scan_helpers import (
 class NaiveStrategy(BaseStrategy):
     def __init__(self, *args):
         super(NaiveStrategy, self).__init__(*args)
+        self.gamestate = GameState.IN_GAME  # allows starting OCR mid-game
         self.tasks = self.setup_tasks()
         self.interpolate = config["calibration.color_interpolation"]
 
@@ -81,7 +82,7 @@ class NaiveStrategy(BaseStrategy):
 
         if self.lines and self.score and self.level:
             self.gamestate = GameState.IN_GAME
-            if self.lines == "000" and self.score == "000000":
+            if (self.lines == "000" or self.lines == "025") and self.score == "000000":
                 return True
 
         return False


### PR DESCRIPTION
When starting capture mid-game, `gameid` stays at 0, and game state incorrectly stays at `MENU`. 

Opening a small changeset for discussion.