### PR TITLE
Replace deprecated antialias with lanczos

### DIFF
--- a/nestris_ocr/assets/sample_inputs/easiercap/test_color1.py
+++ b/nestris_ocr/assets/sample_inputs/easiercap/test_color1.py
@@ -43,13 +43,13 @@ def runFor(level, color, iterations=1):
 
     start = time.time()
     for i in range(iterations):
-        color = original_img.resize((1, 1), Image.ANTIALIAS).getpixel((0, 0))
+        color = original_img.resize((1, 1), Image.LANCZOS).getpixel((0, 0))
 
     elapsed = time.time() - start
     print("antialias", elapsed, elapsed / iterations)
     print("antialias", color)
 
-    tmp = original_img.resize((1, 1), Image.ANTIALIAS).resize(
+    tmp = original_img.resize((1, 1), Image.LANCZOS).resize(
         (big_size, big_size), Image.NEAREST
     )
     result_image.paste(tmp, (span * 3, result_y))
@@ -127,13 +127,13 @@ def runFor(level, color, iterations=1):
 
     start = time.time()
     for i in range(iterations):
-        color = cropped.resize((1, 1), Image.ANTIALIAS).getpixel((0, 0))
+        color = cropped.resize((1, 1), Image.LANCZOS).getpixel((0, 0))
 
     elapsed = time.time() - start
     print("cropped,antilias", elapsed, elapsed / iterations)
     print("cropped,antilias", color)
 
-    tmp = cropped.resize((1, 1), Image.ANTIALIAS).resize(
+    tmp = cropped.resize((1, 1), Image.LANCZOS).resize(
         (big_size, big_size), Image.NEAREST
     )
     result_image.paste(tmp, (span * 3, result_y + row_idx * span))

--- a/nestris_ocr/assets/sample_inputs/easiercap/test_distances.py
+++ b/nestris_ocr/assets/sample_inputs/easiercap/test_distances.py
@@ -20,7 +20,7 @@ def crop(source):
 
 
 def getColorExisting(colImg):
-    return colImg.resize((1, 1), Image.ANTIALIAS).getpixel((0, 0))
+    return colImg.resize((1, 1), Image.LANCZOS).getpixel((0, 0))
 
 
 def getColorCropBlurNearest(colImg):
@@ -28,7 +28,7 @@ def getColorCropBlurNearest(colImg):
 
 
 def getColorCropAntialias(colImg):
-    return crop(colImg).resize((1, 1), Image.ANTIALIAS).getpixel((0, 0))
+    return crop(colImg).resize((1, 1), Image.LANCZOS).getpixel((0, 0))
 
 
 def getColorCropBox(colImg):

--- a/nestris_ocr/calibration/draw_calibration.py
+++ b/nestris_ocr/calibration/draw_calibration.py
@@ -281,5 +281,5 @@ def draw_calibration(config):
         for i in range(10):
             uncached_capture().get_image(rgb=True)
     highlight_calibration(img, config)
-    img = img.resize((512, 448), Image.ANTIALIAS)
+    img = img.resize((512, 448), Image.LANCZOS)
     return img

--- a/nestris_ocr/ocr_algo/digit.py
+++ b/nestris_ocr/ocr_algo/digit.py
@@ -37,7 +37,7 @@ def setupColour(prefix, outputDict, digitList):
         img = img.convert("L")
         if IMAGE_MULT != 1:
             img = img.resize(
-                (SCALED_IMAGE_SIZE, SCALED_IMAGE_SIZE), PIL.Image.ANTIALIAS
+                (SCALED_IMAGE_SIZE, SCALED_IMAGE_SIZE), PIL.Image.LANCZOS
             )
 
         img = img.getdata()
@@ -89,7 +89,7 @@ def contrastImg(img):
 
 def convertImg(img, count, show):
     img = contrastImg(img)
-    img = img.resize(finalImageSize(count), PIL.Image.ANTIALIAS)
+    img = img.resize(finalImageSize(count), PIL.Image.LANCZOS)
 
     if show:
         img.show()


### PR DESCRIPTION
Hello!  I got an error while trying to run this and found some references that had been deprecated.  I replaced it with LANCZOS according to https://pillow.readthedocs.io/en/stable/deprecations.html.   